### PR TITLE
Ignores test fixtures folder from symfony/dependency-injection

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -63,6 +63,8 @@
     <exclude name="sites/all/modules/coder/**/*.php" />
     <exclude name="sites/all/modules/coder/**/*.inc" />
     <exclude name="sites/all/modules/coder/**/*.module" />
+    <!-- @see: https://github.com/symfony/symfony/issues/11921 -->
+    <exclude name="sites/all/libraries/**/Tests/**/*.php" />
     <modified>
       <param name="cache.cachefile" value="../cache.properties.${project}"/>
     </modified>


### PR DESCRIPTION
This is fix for the following error in Jenkins CI during dev deployment during `lint` checks:

>     [apply] Errors parsing /var/jenkins/workspace/Digirati/NTDP_Alpha_website/docroot/sites/all/libraries/composer/symfony/dependency-injection/Tests/Fixtures/php/services1-1.php

>     [apply] PHP Fatal error:  Cannot declare class Symfony\Component\DependencyInjection\Dump\Container because the name is already in use in /var/jenkins/workspace/Digirati/NTDP_Alpha_website/docroot/sites/all/libraries/composer/symfony/dependency-injection/Tests/Fixtures/php/services1-1.php on line 18

See: symfony/symfony/issues/11921