### PR TITLE
Ignores Resources/ folder from lint checking

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -65,6 +65,8 @@
     <exclude name="sites/all/modules/coder/**/*.module" />
     <!-- @see: https://github.com/symfony/symfony/issues/11921 -->
     <exclude name="sites/all/libraries/**/Tests/**/*.php" />
+    <!-- @see: https://github.com/symfony/polyfill/issues/108 -->
+    <exclude name="sites/all/libraries/**/Resources/**/*.php" />
     <modified>
       <param name="cache.cachefile" value="../cache.properties.${project}"/>
     </modified>


### PR DESCRIPTION
This fixes the following error when checking for the PHP syntax:

> PHP Fatal error:  Cannot redeclare class CallbackFilterIterator in docroot/sites/all/libraries/composer/symfony/polyfill-php54/Resources/stubs/CallbackFilterIterator.php on line 28

Refs: symfony/polyfill/issues/108